### PR TITLE
fix problems that arise when not root

### DIFF
--- a/definitions/bundle_install.rb
+++ b/definitions/bundle_install.rb
@@ -7,7 +7,11 @@ define :bundle_install do
   # bundle install
   execute 'bundle install' do
     cwd params[:path]
-    command "bundle install"
+    if params[:user] == 'root'
+      command 'bundle install'
+    else
+      command 'bundle install --path vendor/bundle'
+    end
     user params[:user]
     only_if { File.directory?(params[:path]) }
   end

--- a/templates/default/service.erb
+++ b/templates/default/service.erb
@@ -32,7 +32,7 @@ start() {
     echo "Starting $NAME"
     cd $DAEMONDIR
     touch $PIDFILE ; chown <%= @user %> $PIDFILE
-    su <%= @user %> -c "<%= @run_command %> $DAEMON >> $DAEMONDIR/plugin_daemon.log 2>&1 & echo \$! > $PIDFILE"
+    su <%= @user %> -s '/bin/bash' -c "<%= @run_command %> $DAEMON >> $DAEMONDIR/plugin_daemon.log 2>&1 & echo \$! > $PIDFILE"
   fi
 }
 


### PR DESCRIPTION
according to [https://docs.newrelic.com/docs/servers/new-relic-servers-linux/installation-configuration/servers-installation-other-linux#user], the `newrelic` user should be created with shell `/sbin/nologin`.  the init script cannot run without a shell, so by providing `-s /bin/bash`, it can.
additionally, the `newrelic` user cannot install system gems, so the gems should be vendored.  