### PR TITLE
Allow all 2.x ruby versions

### DIFF
--- a/definitions/verify_ruby.rb
+++ b/definitions/verify_ruby.rb
@@ -5,7 +5,7 @@ define :verify_ruby do
   ruby_block "verify ruby for #{params[:name]}" do
     block do
       # check ruby dependency - exclude chef's embedded ruby
-      unless node[:languages][:ruby] && node[:languages][:ruby][:version].start_with?('1.8.7', '1.9', '2.0', '2.1') &&
+      unless node[:languages][:ruby] && node[:languages][:ruby][:version].start_with?('1.8.7', '1.9', '2') &&
         node[:languages][:ruby][:ruby_bin] !~ /chef/
         Chef::Application.fatal!("The New Relic #{params[:name]} requires a Ruby version >= 1.8.7 -" +
           " For more information, see https://docs.newrelic.com/docs/plugins/installing-a-plugin")


### PR DESCRIPTION
The error message says that ruby >= 1.8.7 is required, but the code explicitly checks for 2.0 and 2.1, disallowing versions 2.2 and above.

https://ruby-doc.org/stdlib-2.3.0/libdoc/rubygems/rdoc/Gem/Version.html would probably be a better way to compare the version numbers, but I don't know if that works with all supported ruby versions.