### PR TITLE
Support getting credentials from instance metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -56,14 +56,21 @@ attribute 'newrelic/aws_cloudwatch/aws_access_key',
   :display_name => 'New Relic AWS Cloudwatch Plugin Access Key',
   :description => 'AWS Access Key for New Relic AWS Cloudwatch Plugin',
   :type => 'string',
-  :required => 'required',
+  :required => 'optional',
   :recipes => ['newrelic_plugins::aws_cloudwatch']
 
 attribute 'newrelic/aws_cloudwatch/aws_secret_key',
   :display_name => 'New Relic AWS Cloudwatch Plugin Secret Key',
   :description => 'AWS Secret Key for New Relic AWS Cloudwatch Plugin',
   :type => 'string',
-  :required => 'required',
+  :required => 'optional',
+  :recipes => ['newrelic_plugins::aws_cloudwatch']
+
+attribute 'newrelic/aws_cloudwatch/use_aws_metadata',
+  :display_name => 'New Relic AWS Cloudwatch Plugin Use Instance Metadata',
+  :description => 'Use Instance Metadata for New Relic AWS Cloudwatch Plugin',
+  :type => 'boolean',
+  :required => 'optional',
   :recipes => ['newrelic_plugins::aws_cloudwatch']
 
 attribute 'newrelic/aws_cloudwatch/agents',

--- a/recipes/aws_cloudwatch.rb
+++ b/recipes/aws_cloudwatch.rb
@@ -7,8 +7,6 @@ verify_attributes do
     'node[:newrelic][:license_key]', 
     'node[:newrelic][:aws_cloudwatch][:install_path]', 
     'node[:newrelic][:aws_cloudwatch][:user]',
-    'node[:newrelic][:aws_cloudwatch][:aws_access_key]', 
-    'node[:newrelic][:aws_cloudwatch][:aws_secret_key]', 
     'node[:newrelic][:aws_cloudwatch][:agents]'
   ]
 end

--- a/templates/default/aws_cloudwatch/newrelic_plugin.yml.erb
+++ b/templates/default/aws_cloudwatch/newrelic_plugin.yml.erb
@@ -16,8 +16,18 @@ newrelic:
 #
 aws:
   # Update with your AWS account keys:
+  <%- if node[:newrelic][:aws_cloudwatch][:aws_access_key] %>
   access_key: '<%= node[:newrelic][:aws_cloudwatch][:aws_access_key] %>'
+  <%- end %>
+  <%- if node[:newrelic][:aws_cloudwatch][:aws_secret_key] %>
   secret_key: '<%= node[:newrelic][:aws_cloudwatch][:aws_secret_key] %>'
+  <%- end %>
+
+  # Disable the key checks and enable usage of AWS instance metadata for setting keys
+  <%- if node[:newrelic][:aws_cloudwatch][:use_aws_metadata] %>
+  use_aws_metadata: <%= node[:newrelic][:aws_cloudwatch][:use_aws_metadata] %>
+  <%- end %>
+
   # Specify AWS regions to query for metrics
   # regions:
   #   us-east-1


### PR DESCRIPTION
This is needed to allow using IAM Instance Profiles rather than hard coding the keys in the config file.